### PR TITLE
Fixing AsyncStreamController type

### DIFF
--- a/lib/JanusPlugin.dart
+++ b/lib/JanusPlugin.dart
@@ -122,7 +122,7 @@ class JanusPlugin {
     _localStreamController = StreamController<MediaStream>();
     localStream = _localStreamController.stream.asBroadcastStream();
     //source and stream for plugin level events
-    _messagesStreamController = StreamController<dynamic>();
+    _messagesStreamController = StreamController<EventMessage>();
     messages = _messagesStreamController.stream.asBroadcastStream();
 
     // remote track for unified plan support


### PR DESCRIPTION
The controller type of dynamic throws an error so because we expect this message controller to be of type EventMessage I have just changed it to that