### PR TITLE
Fix "unsubscribe" event in video_room example

### DIFF
--- a/example/lib/typed_examples/video_room.dart
+++ b/example/lib/typed_examples/video_room.dart
@@ -189,7 +189,7 @@ class _VideoRoomState extends State<TypedVideoRoomV2Unified> {
     var unsubscribe = {
       "request": "unsubscribe",
       "streams": [
-        {feed: id}
+        {"feed": id}
       ]
     };
     if (remoteHandle != null)


### PR DESCRIPTION
The unsubscribe event in video room example is failing because feed object is being passed instead of string as key.