### PR TITLE
Fix audio bridge plugin joinRoom datatype of field "id"

### DIFF
--- a/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
+++ b/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
@@ -140,7 +140,7 @@ class JanusAudioBridgePlugin extends JanusPlugin {
   ///[filename] : "basename of the file to record to, -audio.mjr will be added by the plugin<br>
   ///
   Future<void> joinRoom(dynamic roomId,
-      {String? id,
+      {int? id,
       String? group,
       String? pin,
       int? expectedLoss,

--- a/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
+++ b/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
@@ -140,7 +140,7 @@ class JanusAudioBridgePlugin extends JanusPlugin {
   ///[filename] : "basename of the file to record to, -audio.mjr will be added by the plugin<br>
   ///
   Future<void> joinRoom(dynamic roomId,
-      {int? id,
+      {dynamic id,
       String? group,
       String? pin,
       int? expectedLoss,


### PR DESCRIPTION
Getting this error while joining audio bridge room with id since int type is expected in the janus APIs.
```[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: JanusError{ error_code: 484, error: Invalid element type (id should be a positive integer), pluginName: audiobridge, event: null,}```