### PR TITLE
Add audiobridge destroyed event

### DIFF
--- a/example/lib/typed_examples/audio_bridge.dart
+++ b/example/lib/typed_examples/audio_bridge.dart
@@ -121,6 +121,7 @@ class _AudioRoomState extends State<TypedAudioRoomV2> {
         });
       }
       if (data is AudioBridgeConfiguredEvent) {}
+      if (data is AudioBridgeDestroyedEvent) {}
       if (data is AudioBridgeLeavingEvent) {
         setState(() {
           participants.remove(data.leaving.toString());

--- a/lib/interfaces/audio_bridge/events/audio_bridge_destroyed_event.dart
+++ b/lib/interfaces/audio_bridge/events/audio_bridge_destroyed_event.dart
@@ -1,0 +1,20 @@
+part of janus_client;
+
+class AudioBridgeDestroyedEvent extends AudioBridgeEvent {
+  AudioBridgeDestroyedEvent({audiobridge, room}) {
+    super.audiobridge = audiobridge;
+    super.room = room;
+  }
+
+  AudioBridgeDestroyedEvent.fromJson(dynamic json) {
+    audiobridge = json['audiobridge'];
+    room = json['room'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    map['audiobridge'] = audiobridge;
+    map['room'] = room;
+    return map;
+  }
+}

--- a/lib/janus_client.dart
+++ b/lib/janus_client.dart
@@ -97,6 +97,8 @@ part './interfaces/audio_bridge/events/audio_bridge_event.dart';
 
 part './interfaces/audio_bridge/events/audio_bridge_talking_event.dart';
 
+part './interfaces/audio_bridge/events/audio_bridge_destroyed_event.dart';
+
 part './interfaces/audio_bridge/events/audio_bridge_joined_event.dart';
 
 part './interfaces/audio_bridge/events/audio_bridge_leaving_event.dart';

--- a/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
+++ b/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
@@ -398,6 +398,12 @@ class JanusAudioBridgePlugin extends JanusPlugin {
           typedEvent.event.plugindata?.data = AudioBridgeTalkingEvent.fromJson(
               typedEvent.event.plugindata?.data);
           _typedMessagesSink?.add(typedEvent);
+        } else if (typedEvent.event.plugindata?.data["audiobridge"] ==
+            "destroyed") {
+          typedEvent.event.plugindata?.data =
+              AudioBridgeDestroyedEvent.fromJson(
+                  typedEvent.event.plugindata?.data);
+          _typedMessagesSink?.add(typedEvent);
         }
 
         /// not tested


### PR DESCRIPTION
Audiobridge room can be destroyed on the janus server upon which it sends in a "destroyed" event for the client to perform clean up. I have added the typed event for the same.

```json
{
        "audiobridge" : "destroyed",
        "room" : <unique numeric ID of the destroyed room>
}
```