### PR TITLE
Add opaque id in "attach" event if provided

### DIFF
--- a/lib/janus_session.dart
+++ b/lib/janus_session.dart
@@ -61,7 +61,7 @@ class JanusSession {
     }
   }
 
-  Future<T> attach<T extends JanusPlugin>() async {
+  Future<T> attach<T extends JanusPlugin>({String? opaqueId}) async {
     JanusPlugin plugin;
     int? handleId;
     String transaction = getUuid().v4();
@@ -69,6 +69,9 @@ class JanusSession {
       "janus": "attach",
       "transaction": transaction
     };
+    if (opaqueId != null) {
+      request["opaque_id"] = opaqueId;
+    }
     request["token"] = _context._token;
     request["apisecret"] = _context._apiSecret;
     request["session_id"] = sessionId;

--- a/lib/janus_session.dart
+++ b/lib/janus_session.dart
@@ -61,6 +61,8 @@ class JanusSession {
     }
   }
 
+  /// This can be used to attach plugin handle to the session.<br><br>
+  /// [opaqueId] : opaque id is an optional string identifier used for client side correlations in event handlers or admin API.<br>
   Future<T> attach<T extends JanusPlugin>({String? opaqueId}) async {
     JanusPlugin plugin;
     int? handleId;


### PR DESCRIPTION
Add opaque id optional field in the plugin attach event. This helps draw correlations for event handlers.

Details on opaque_id field
https://github.com/meetecho/janus-gateway/pull/748

I have tested this for both stringIds true & false. For both I have tried invoking the function with & without this parameter.