### PR TITLE
Ft/websocket errors

### DIFF
--- a/lib/janus_plugin.dart
+++ b/lib/janus_plugin.dart
@@ -135,6 +135,10 @@ class JanusPlugin {
       _wsStreamSubscription =
           (_transport as WebSocketJanusTransport).stream.listen((event) {
         _streamController!.add(parse(event));
+      }, onDone: () {
+        _messagesStreamController?.sink.close();
+      }, onError: (error) {
+        _messagesStreamController?.sink.addError(error);
       });
     }
   }

--- a/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
+++ b/lib/wrapper_plugins/janus_audio_bridge_plugin.dart
@@ -414,6 +414,10 @@ class JanusAudioBridgePlugin extends JanusPlugin {
           _typedMessagesSink
               ?.addError(JanusError.fromMap(typedEvent.event.plugindata?.data));
         }
+      }, onDone: () {
+        _typedMessagesSink?.close();
+      }, onError: (error) {
+        _typedMessagesSink?.addError(error);
       });
     }
   }

--- a/lib/wrapper_plugins/janus_sip_plugin.dart
+++ b/lib/wrapper_plugins/janus_sip_plugin.dart
@@ -337,6 +337,10 @@ class JanusSipPlugin extends JanusPlugin {
           _typedMessagesSink
               ?.addError(JanusError.fromMap(typedEvent.event.plugindata?.data));
         }
+      }, onDone: () {
+        _typedMessagesSink?.close();
+      }, onError: (error) {
+        _typedMessagesSink?.addError(error);
       });
     }
   }

--- a/lib/wrapper_plugins/janus_streaming_plugin.dart
+++ b/lib/wrapper_plugins/janus_streaming_plugin.dart
@@ -207,6 +207,10 @@ class JanusStreamingPlugin extends JanusPlugin {
           _typedMessagesSink
               ?.addError(JanusError.fromMap(typedEvent.event.plugindata?.data));
         }
+      }, onDone: () {
+        _typedMessagesSink?.close();
+      }, onError: (error) {
+        _typedMessagesSink?.addError(error);
       });
     }
   }

--- a/lib/wrapper_plugins/janus_video_call_plugin.dart
+++ b/lib/wrapper_plugins/janus_video_call_plugin.dart
@@ -144,6 +144,10 @@ class JanusVideoCallPlugin extends JanusPlugin {
           _typedMessagesSink
               ?.addError(JanusError.fromMap(typedEvent.event.plugindata?.data));
         }
+      }, onDone: () {
+        _typedMessagesSink?.close();
+      }, onError: (error) {
+        _typedMessagesSink?.addError(error);
       });
     }
   }

--- a/lib/wrapper_plugins/janus_video_room_plugin.dart
+++ b/lib/wrapper_plugins/janus_video_room_plugin.dart
@@ -336,6 +336,10 @@ class JanusVideoRoomPlugin extends JanusPlugin {
           _typedMessagesSink
               ?.addError(JanusError.fromMap(typedEvent.event.plugindata?.data));
         }
+      }, onDone: () {
+        _typedMessagesSink?.close();
+      }, onError: (error) {
+        _typedMessagesSink?.addError(error);
       });
     }
   }


### PR DESCRIPTION
Added onDone & onError callback functions for websocket transport for disconnections & errors. The callbacks relay back this information through typedMessageSink to the application.