### PR TITLE
Google Meet Example simulcast support

### DIFF
--- a/example/lib/util.dart
+++ b/example/lib/util.dart
@@ -9,6 +9,7 @@ class StreamRenderer {
   String? publisherName;
   String? mid;
   bool? isAudioMuted;
+  List<bool> selectedQuality=[false,false,true];
   bool? isVideoMuted;
 
   Future<void> dispose() async {


### PR DESCRIPTION

This pr brings simulcast support(#130) in google meet example as well as in 
```dart
  Future<MediaStream?> initializeMediaDevices({bool? useDisplayMediaDevices = false, List<RTCRtpEncoding>? simulcastSendEncodings, Map<String, dynamic>? mediaConstraints})
  ```
  can be used as 
  ```dart
  localVideoRenderer.mediaStream = await videoPlugin?.initializeMediaDevices(simulcastSendEncodings: [
      RTCRtpEncoding(active: true, rid: 'h', maxBitrate: 4000000),
      RTCRtpEncoding(active: true, rid: 'm', maxBitrate: 1000000, scaleResolutionDownBy: 2),
      RTCRtpEncoding(active: true, rid: 'l', maxBitrate: 1000000, scaleResolutionDownBy: 3),
    ], mediaConstraints: {
      'video': {
        'width': {'ideal': 1920},
        'height': {'ideal': 1080}
      },
      'audio': true
    });
  ```
  omitting  `simulcastSendEncodings` will fallback to `addTrack` therefore no simulcasting or svc can be expected in that case.