### PR TITLE
Mulitple Fixes to _handlePolling

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -192,7 +192,22 @@ stringify(dynamic) {
 
 parse(dynamic) {
   JsonDecoder jsonDecoder = JsonDecoder();
+  if(dynamic == null || dynamic.toString().isEmpty) dynamic = "{}";
   return jsonDecoder.convert(dynamic);
+}
+
+String extractDomainFromUrl(String url) {
+  if (url.startsWith('https://')) {
+    url = url.substring('https://'.length);
+  } else if (url.startsWith('http://')) {
+    url = url.substring('http://'.length);
+  }
+  int pathIndex = url.indexOf('/');
+  if (pathIndex != -1) {
+    return url.substring(0, pathIndex);
+  } else {
+    return url;
+  }
 }
 
 randomString({int len = 10, String charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@#\$%^&*()_+'}) {


### PR DESCRIPTION
Multiple fixes :
 - fix `Uri.parse` is not working with https and not working if an encryption layer is added to token and session id , so instead so we replace it bt `Uri.https` that accept both `http` and `https`
 - Add more information when we receive a non 200 status code from the janus gateway
 - add a helper method to extract the domain needed by `Uri.https`  to make the flow more smooth 
 - fix `parse` method that was throwing error if the return is an empty string 