### PR TITLE
Fix flutterjanus/flutter_janus_client#164

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -100,8 +100,8 @@ class RTCIceServer {
 
   Map<String, dynamic> toMap() {
     return {
-      'username': this.username,
-      'credential': this.credential,
+      if (username != null) 'username': this.username,
+      if (credential != null) 'credential': this.credential,
       'urls': this.urls,
     };
   }


### PR DESCRIPTION
Fixes platform crash due to inclusion of `username` and `credential` field, if they are null.